### PR TITLE
Replaced `double` and `float` with `decimal`

### DIFF
--- a/Fovero/Model/Point2D.cs
+++ b/Fovero/Model/Point2D.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fovero.Model;
 
-public record Point2D(double X, double Y) : IComparable<Point2D>
+public record Point2D(decimal X, decimal Y) : IComparable<Point2D>
 {
     public Point2D MidpointTo(Point2D endPoint)
     {

--- a/Fovero/Model/Rectangle.cs
+++ b/Fovero/Model/Rectangle.cs
@@ -1,6 +1,6 @@
 ﻿namespace Fovero.Model;
 
-public record Rectangle(double X, double Y, double Width, double Height)
+public record Rectangle(decimal X, decimal Y, decimal Width, decimal Height)
 {
     public Rectangle(Point2D topLeft, Point2D bottomRight) : this(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y)
     {
@@ -8,9 +8,9 @@ public record Rectangle(double X, double Y, double Width, double Height)
 
     public Point2D Center => new(X + Width / 2, Y + Height / 2);
 
-    public double Left => X;
-    public double Top => Y;
+    public decimal Left => X;
+    public decimal Top => Y;
 
-    public double Right => X + Width;
-    public double Bottom => Y + Height;
+    public decimal Right => X + Width;
+    public decimal Bottom => Y + Height;
 }

--- a/Fovero/Model/Tiling/HexagonalTiling.cs
+++ b/Fovero/Model/Tiling/HexagonalTiling.cs
@@ -4,7 +4,7 @@ namespace Fovero.Model.Tiling;
 
 public class HexagonalTiling(int columns, int rows) : RegularTiling("Hexagonal", columns, rows)
 {
-    private static float CellHeight { get; } = (float)Math.Sqrt(3);
+    private static decimal CellHeight { get; } = (decimal)Math.Sqrt(3);
 
     protected override ITile CreateTile(int col, int row)
     {
@@ -30,7 +30,7 @@ public class HexagonalTiling(int columns, int rows) : RegularTiling("Hexagonal",
 
         public Point2D Center => Bounds.Center;
 
-        public Rectangle Bounds => new(_column * 1.5f, _row * CellHeight + (_isEvenColumn ? 0 : CellHeight / 2f), 2, CellHeight);
+        public Rectangle Bounds => new(_column * 1.5M, _row * CellHeight + (_isEvenColumn ? 0 : CellHeight / 2M), 2, CellHeight);
 
         private IEnumerable<Point2D> CornerPoints
         {
@@ -38,11 +38,11 @@ public class HexagonalTiling(int columns, int rows) : RegularTiling("Hexagonal",
             {
                 var bounds = Bounds;
 
-                yield return new Point2D(bounds.Left + 0.5f, bounds.Top);
-                yield return new Point2D(bounds.Right - 0.5f, bounds.Top);
+                yield return new Point2D(bounds.Left + 0.5M, bounds.Top);
+                yield return new Point2D(bounds.Right - 0.5M, bounds.Top);
                 yield return bounds.Center with { X = bounds.Right };
-                yield return new Point2D(bounds.Right - 0.5f, bounds.Bottom);
-                yield return new Point2D(bounds.Left + 0.5f, bounds.Bottom);
+                yield return new Point2D(bounds.Right - 0.5M, bounds.Bottom);
+                yield return new Point2D(bounds.Left + 0.5M, bounds.Bottom);
                 yield return bounds.Center with { X = bounds.Left };
             }
         }

--- a/Fovero/Model/Tiling/PyramidTiling.cs
+++ b/Fovero/Model/Tiling/PyramidTiling.cs
@@ -4,7 +4,7 @@ namespace Fovero.Model.Tiling;
 
 public class PyramidTiling(int height) : ITiling
 {
-    private static float CellHeight { get; } = (float)Math.Sqrt(3) / 2;
+    private static decimal CellHeight { get; } = (decimal)Math.Sqrt(3) / 2;
 
     public int Height { get; } = height;
 
@@ -63,7 +63,7 @@ public class PyramidTiling(int height) : ITiling
 
         public Point2D Center => Bounds.Center;
 
-        public Rectangle Bounds => new((_format.Height - _row + _column) / 2f, _row * CellHeight, 1, CellHeight);
+        public Rectangle Bounds => new((_format.Height - _row + _column) / 2M, _row * CellHeight, 1, CellHeight);
 
         private IEnumerable<Point2D> CornerPoints
         {

--- a/Fovero/Model/Tiling/TriangularTiling.cs
+++ b/Fovero/Model/Tiling/TriangularTiling.cs
@@ -5,7 +5,7 @@ namespace Fovero.Model.Tiling;
 // Rectangular Delta (Hexagonal Delta, Triangular Delta)
 public sealed class TriangularTiling(int columns, int rows) : RegularTiling("Triangular", columns, rows)
 {
-    private static float CellHeight { get; } = (float)Math.Sqrt(3) / 2;
+    private static decimal CellHeight { get; } = (decimal)Math.Sqrt(3) / 2M;
 
     protected override ITile CreateTile(int col, int row)
     {
@@ -31,7 +31,7 @@ public sealed class TriangularTiling(int columns, int rows) : RegularTiling("Tri
 
         public Point2D Center => Bounds.Center;
 
-        public Rectangle Bounds => new(_column / 2f, _row * CellHeight, 1, CellHeight);
+        public Rectangle Bounds => new(_column / 2M, _row * CellHeight, 1, CellHeight);
 
         private IEnumerable<Point2D> CornerPoints
         {

--- a/Fovero/Model/Tiling/TruncatedSquareTiling.cs
+++ b/Fovero/Model/Tiling/TruncatedSquareTiling.cs
@@ -32,8 +32,8 @@ public class TruncatedSquareTiling(int columns, int rows) : RegularTiling("Trunc
         {
             get
             {
-                var c = (_column >> 1) * 4f;
-                var r = (_row >> 1) * 4f;
+                var c = (_column >> 1) * 4M;
+                var r = (_row >> 1) * 4M;
 
                 return _isSquare
                     ? new(c + (_column % 2 == 0 ? 1 : 3), r + (_row % 2 == 0 ? 1 : 3), 1, 1)

--- a/Fovero/UI/Wall.cs
+++ b/Fovero/UI/Wall.cs
@@ -4,7 +4,7 @@ using Fovero.Model.Tiling;
 
 namespace Fovero.UI;
 
-public sealed class Wall(IEdge edge, double scaling) : PropertyChangedBase, IWall
+public sealed class Wall(IEdge edge, decimal scaling) : PropertyChangedBase, IWall
 {
     private bool _isOpen;
 
@@ -12,13 +12,13 @@ public sealed class Wall(IEdge edge, double scaling) : PropertyChangedBase, IWal
 
     public bool IsShared => Edge is SharedEdge;
 
-    public double X1 => Edge.Start.X * scaling;
+    public decimal X1 => Edge.Start.X * scaling;
 
-    public double Y1 => Edge.Start.Y * scaling;
+    public decimal Y1 => Edge.Start.Y * scaling;
 
-    public double X2 => Edge.End.X * scaling;
+    public decimal X2 => Edge.End.X * scaling;
 
-    public double Y2 => Edge.End.Y * scaling;
+    public decimal Y2 => Edge.End.Y * scaling;
 
     public string Geometry => $"M {X1},{Y1} {X2},{Y2}";
 


### PR DESCRIPTION
## Issue
Edges are supposed to be uniquely identified with the property `Ordinal`: this is calculated from the edge's visual representation values, which are expressed as `double`. The lack of accuracy of this type sometimes causes off-by-one `Ordinal` calculation, resulting in a double representation of the same edge.

## Fix
Here I fixed by substituting all `double` and `float` values with `decimal` values, for the accuracy of this type avoids rounding errors.

## Possible alternative fix
I think a better fix would however involve decoupling the calculation of `Ordinal` from the visual representation of the edge, relying instead only on its meaning as a relationship between two tiles.
This said, I think all edges should be treated as `SharedEdge`, and the outside edges should represent the relationship with a tile that doesn't belong to the maze.