### PR TITLE
Fixed Hunt and Kill generation algorithm

### DIFF
--- a/Fovero/Model/Generators/BuildingStrategy.cs
+++ b/Fovero/Model/Generators/BuildingStrategy.cs
@@ -45,18 +45,18 @@ public record BuildingStrategy<T>(string Name, Func<IReadOnlyList<T>, Random, IE
                 var allLinks = CreateLookup(allWalls, random);
                 var cell = allLinks.First().Key;
 
-                var unvisitedCells = new HashSet<ushort>(allLinks.Select(x => x.Key));
+                var unvisitedCells = new HashSet<ushort>(allLinks.Select(x => x.Key).Where(x => x != cell));
 
-                while (unvisitedCells.Count > 0)
+                while (unvisitedCells.Any())
                 {
                     var toJoin = allLinks[cell]
                                      .FirstOrDefault(x => unvisitedCells.Contains(x.Neighbor)) ??
                                  allLinks
-                                     .Where(x => unvisitedCells.Contains(x.Key))
+                                     .Where(x => !unvisitedCells.Contains(x.Key))
                                      .SelectMany(neighboringCells => neighboringCells)
-                                     .First(link => !unvisitedCells.Contains(link.Neighbor));
+                                     .First(link => unvisitedCells.Contains(link.Neighbor));
 
-                    unvisitedCells.Remove(toJoin.Cell);
+                    unvisitedCells.Remove(toJoin.Neighbor);
                     cell = toJoin.Neighbor;
 
                     yield return toJoin.Wall;


### PR DESCRIPTION
I didn't really understand the concept behind this algorithm from the code, as in my eyes it simply looks like a recursive backtracking algorithm that, once a dead end is created, instead of going back to the latest visited cell with access to a viable unexplored path, resumes the search from a "random" visited cell.

Disclaimer: I may have completely misunderstood the concept of the algorithm and modified it into something different instead of fixing it

An additional `.Shuffle()` may also be added before line 57, but the algorithm generates more interesting mazes without as it is more likely to end up with several cells with >2 choices.