### PR TITLE
Fixed loops in Hunt and Kill generator

### DIFF
--- a/Fovero/Model/Generators/BuildingStrategy.cs
+++ b/Fovero/Model/Generators/BuildingStrategy.cs
@@ -52,6 +52,8 @@ public partial record BuildingStrategy<T>(string Name, Func<IReadOnlyList<T>, Ra
 
                 var cell = layout.RandomUnvisited;
 
+                cell.HasBeenVisited = true;
+
                 while (!layout.IsComplete)
                 {
                     var stepToNeighbor =


### PR DESCRIPTION
This would happen when visiting a neighboring cell of the initial cell chosen (considered as unvisited) and selecting their shared wall for removal.